### PR TITLE
Improve missing argument error reporting

### DIFF
--- a/Sources/GuiseFramework/BuildArguments.swift
+++ b/Sources/GuiseFramework/BuildArguments.swift
@@ -40,7 +40,13 @@ struct BuildArgumentsExtractor {
 
   func makeBuildArguments() throws -> BuildArguments {
     do {
-      return try JSONDecoder().decode(BuildArguments.self, from: JSONEncoder().encode(environment))
+      let buildArguments = try JSONDecoder().decode(BuildArguments.self, from: JSONEncoder().encode(environment))
+      
+      if buildArguments.phoneOSDeploymentTarget == nil && buildArguments.macOSDeploymentTarget == nil {
+        throw APIGeneratorError.buildArgumentRequired(name: "\(BuildArguments.CodingKeys.phoneOSDeploymentTarget.rawValue) or \(BuildArguments.CodingKeys.macOSDeploymentTarget.rawValue)")
+      }
+      
+      return buildArguments
     } catch DecodingError.keyNotFound(let key, _) {
       throw APIGeneratorError.buildArgumentRequired(name: key.stringValue)
     }

--- a/Sources/GuiseFramework/BuildArguments.swift
+++ b/Sources/GuiseFramework/BuildArguments.swift
@@ -39,7 +39,11 @@ struct BuildArgumentsExtractor {
   }
 
   func makeBuildArguments() throws -> BuildArguments {
-    return try JSONDecoder().decode(BuildArguments.self, from: JSONEncoder().encode(environment))
+    do {
+      return try JSONDecoder().decode(BuildArguments.self, from: JSONEncoder().encode(environment))
+    } catch DecodingError.keyNotFound(let key, _) {
+      throw APIGeneratorError.buildArgumentRequired(name: key.stringValue)
+    }
   }
   
 }

--- a/Tests/GuiseFrameworkTests/BuildArgumentTests.swift
+++ b/Tests/GuiseFrameworkTests/BuildArgumentTests.swift
@@ -72,5 +72,23 @@ final class BuildArgumentTests: XCTestCase {
     }
     
   }
+  
+  func testDecodeThrowsBuildArgumentRequiredForMissingDeploymentTarget() throws {
+    
+    var environmentWithNoDeploymentTarget = environment
+    environmentWithNoDeploymentTarget.removeValue(forKey: "IPHONEOS_DEPLOYMENT_TARGET")
+    environmentWithNoDeploymentTarget.removeValue(forKey: "MACOSX_DEPLOYMENT_TARGET")
+    
+    let extractor = BuildArgumentsExtractor(environment: environmentWithNoDeploymentTarget)
+    
+    XCTAssertThrowsError(try extractor.makeBuildArguments()) { error in
+      guard case .buildArgumentRequired(name: let missingArgument)? = error as? APIGeneratorError else {
+        return XCTFail("Expecting APIGenerator.buildArgumentRequired(name:) error.")
+      }
+      
+      XCTAssertEqual(missingArgument, "IPHONEOS_DEPLOYMENT_TARGET or MACOSX_DEPLOYMENT_TARGET")
+    }
+    
+  }
 
 }

--- a/Tests/GuiseFrameworkTests/BuildArgumentTests.swift
+++ b/Tests/GuiseFrameworkTests/BuildArgumentTests.swift
@@ -55,5 +55,22 @@ final class BuildArgumentTests: XCTestCase {
     XCTAssertEqual(buildArguments.deploymentTarget, "8")
     
   }
+  
+  func testDecodeThrowsBuildArgumentRequired() throws {
+    
+    var environmentWithNoConfigurationBuildDir = environment
+    environmentWithNoConfigurationBuildDir.removeValue(forKey: "CONFIGURATION_BUILD_DIR")
+    
+    let extractor = BuildArgumentsExtractor(environment: environmentWithNoConfigurationBuildDir)
+    
+    XCTAssertThrowsError(try extractor.makeBuildArguments()) { error in
+      guard case .buildArgumentRequired(name: let missingArgument)? = error as? APIGeneratorError else {
+        return XCTFail("Expecting APIGenerator.buildArgumentRequired(name:) error.")
+      }
+      
+      XCTAssertEqual(missingArgument, "CONFIGURATION_BUILD_DIR")
+    }
+    
+  }
 
 }


### PR DESCRIPTION
Using `Decodable` is nice but the errors it will raise for missing keys are not as nice as the ones this project originally reported.

e.g. compare

```
keyNotFound(CodingKeys(stringValue: "CONFIGURATION_BUILD_DIR", intValue: nil), Swift.DecodingError.Context(codingPath: [], debugDescription: "No value associated with key CodingKeys(stringValue: \"CONFIGURATION_BUILD_DIR\", intValue: nil) (\"CONFIGURATION_BUILD_DIR\").", underlyingError: nil))
Fatal error: file /Users/paul/src/swift/Guise/Sources/GuiseFramework/BuildArguments.swift, line 46
```

with

```
CONFIGURATION_BUILD_DIR is required to be set
```

The first commit in this PR maps missing keys to the frameworks own error type `APIGeneratorError.buildArgumentRequired(name:)` that has nicer reporting to the user.

---

In the change we also lost the helpful message when `deploymentTarget` could not be resolved e.g.

```
IPHONEOS_DEPLOYMENT_TARGET or MACOSX_DEPLOYMENT_TARGET is required to be set
```

The second commit - actively queries if `IPHONEOS_DEPLOYMENT_TARGET` or `MACOSX_DEPLOYMENT_TARGET` have been set and throws `APIGeneratorError.buildArgumentRequired(name:)` if not.