### PR TITLE
Remove SwiftOnoneSupport & Comments

### DIFF
--- a/Sources/GuiseFramework/APIGenerator.swift
+++ b/Sources/GuiseFramework/APIGenerator.swift
@@ -1,9 +1,23 @@
 import Foundation
 import SourceKittenFramework
 
+protocol SourceKittenRequest {
+  func send() throws -> [String: SourceKitRepresentable]
+}
+
+extension SourceKittenFramework.Request: SourceKittenRequest { }
+
 struct APIGenerator {
 
   let buildArguments: BuildArguments
+  
+  init(buildArguments: BuildArguments) {
+    self.buildArguments = buildArguments
+  }
+  
+  var makeSourceKittenRequest: (_ yaml: String) -> SourceKittenRequest = { yaml in
+    return Request.yamlRequest(yaml: yaml)
+  }
   
   func generate() throws -> String {
     
@@ -30,7 +44,7 @@ struct APIGenerator {
     key.synthesizedextensions: 1
     """
     
-    guard let source = try Request.yamlRequest(yaml: yaml).send()["key.sourcetext"] as? String else {
+    guard let source = try makeSourceKittenRequest(yaml).send()["key.sourcetext"] as? String else {
       throw APIGeneratorError.noSourceTextGenerated
     }
 

--- a/Sources/GuiseFramework/APIGenerator.swift
+++ b/Sources/GuiseFramework/APIGenerator.swift
@@ -1,23 +1,9 @@
 import Foundation
 import SourceKittenFramework
 
-protocol SourceKittenRequest {
-  func send() throws -> [String: SourceKitRepresentable]
-}
-
-extension SourceKittenFramework.Request: SourceKittenRequest { }
-
 struct APIGenerator {
 
   let buildArguments: BuildArguments
-  
-  init(buildArguments: BuildArguments) {
-    self.buildArguments = buildArguments
-  }
-  
-  var makeSourceKittenRequest: (_ yaml: String) -> SourceKittenRequest = { yaml in
-    return Request.yamlRequest(yaml: yaml)
-  }
   
   func generate() throws -> String {
     
@@ -44,7 +30,7 @@ struct APIGenerator {
     key.synthesizedextensions: 1
     """
     
-    guard let source = try makeSourceKittenRequest(yaml).send()["key.sourcetext"] as? String else {
+    guard let source = try Request.yamlRequest(yaml: yaml).send()["key.sourcetext"] as? String else {
       throw APIGeneratorError.noSourceTextGenerated
     }
 

--- a/Sources/GuiseFramework/CLI/GenerateCommand.swift
+++ b/Sources/GuiseFramework/CLI/GenerateCommand.swift
@@ -81,7 +81,6 @@ struct GenerateCommand: CommandProtocol {
       }
     }
     
-    
     var textProcessors: [TextProcessor] = [
       RemoveSwiftOnoneSupport()
     ]

--- a/Sources/GuiseFramework/TextProcessors/RemoveComments.swift
+++ b/Sources/GuiseFramework/TextProcessors/RemoveComments.swift
@@ -4,9 +4,10 @@ struct RemoveComments: TextProcessor {
 
   func process(input: String) throws -> String {
 
-    return input.split(separator: "\n").filter({ line in
-      line.range(of: " *\\/\\/\\/", options: .regularExpression) == nil
-    }).joined(separator: "\n")
+    return input
+      .split(separator: "\n", omittingEmptySubsequences: false)
+      .filter { $0.range(of: " *\\/{3}", options: .regularExpression) == nil }
+      .joined(separator: "\n")
     
   }
   

--- a/Sources/GuiseFramework/TextProcessors/RemoveComments.swift
+++ b/Sources/GuiseFramework/TextProcessors/RemoveComments.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct RemoveComments: TextProcessor {
+
+  func process(input: String) throws -> String {
+
+    return input.split(separator: "\n").filter({ line in
+      line.range(of: " *\\/\\/\\/", options: .regularExpression) == nil
+    }).joined(separator: "\n")
+    
+  }
+  
+}

--- a/Sources/GuiseFramework/TextProcessors/RemoveSwiftOnoneSupport.swift
+++ b/Sources/GuiseFramework/TextProcessors/RemoveSwiftOnoneSupport.swift
@@ -1,0 +1,7 @@
+struct RemoveSwiftOnoneSupport: TextProcessor {
+  
+  func process(input: String) throws -> String {
+    return input.replacingOccurrences(of: "\nimport SwiftOnoneSupport", with: "")
+  }
+  
+}

--- a/Sources/GuiseFramework/TextProcessors/RemoveSwiftOnoneSupport.swift
+++ b/Sources/GuiseFramework/TextProcessors/RemoveSwiftOnoneSupport.swift
@@ -1,7 +1,9 @@
 struct RemoveSwiftOnoneSupport: TextProcessor {
   
   func process(input: String) throws -> String {
-    return input.replacingOccurrences(of: "\nimport SwiftOnoneSupport", with: "")
+    return input
+      .replacingOccurrences(of: "\nimport SwiftOnoneSupport", with: "")
+      .replacingOccurrences(of: "import SwiftOnoneSupport\n", with: "")
   }
   
 }

--- a/Sources/GuiseFramework/TextProcessors/TextProcessor.swift
+++ b/Sources/GuiseFramework/TextProcessors/TextProcessor.swift
@@ -1,0 +1,3 @@
+protocol TextProcessor {
+  func process(input: String) throws -> String
+}

--- a/Tests/GuiseFrameworkTests/TextProcessors/RemoveCommentsTests.swift
+++ b/Tests/GuiseFrameworkTests/TextProcessors/RemoveCommentsTests.swift
@@ -25,4 +25,30 @@ struct MyStructure {
     
   }
   
+  func testStripCommentsDoNotRemoveWhitespaceLines() throws {
+    
+    let input = """
+/// This is a doc comment for my structure
+struct MyStructure {
+
+  /// This is a doc comment for my property
+  let property: String
+
+}
+"""
+    
+    let expected = """
+struct MyStructure {
+
+  let property: String
+
+}
+"""
+    
+    let systemUnderTest = RemoveComments()
+    
+    XCTAssertEqual(try systemUnderTest.process(input: input), expected)
+    
+  }
+  
 }

--- a/Tests/GuiseFrameworkTests/TextProcessors/RemoveCommentsTests.swift
+++ b/Tests/GuiseFrameworkTests/TextProcessors/RemoveCommentsTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import GuiseFramework
+
+class RemoveCommentsTests: XCTestCase {
+  
+  func testStripComments() throws {
+    
+    let input = """
+/// This is a doc comment for my structure
+struct MyStructure {
+  /// This is a doc comment for my property
+  let property: String
+}
+"""
+    
+    let expected = """
+struct MyStructure {
+  let property: String
+}
+"""
+    
+    let systemUnderTest = RemoveComments()
+    
+    XCTAssertEqual(try systemUnderTest.process(input: input), expected)
+    
+  }
+  
+}

--- a/Tests/GuiseFrameworkTests/TextProcessors/RemoveSwiftOnoneSupportTests.swift
+++ b/Tests/GuiseFrameworkTests/TextProcessors/RemoveSwiftOnoneSupportTests.swift
@@ -3,11 +3,19 @@ import XCTest
 
 class RemoveSwiftOnoneSupportTests: XCTestCase {
   
-  func testRemoveIfPresent() throws {
+  func testRemoveIfPresentAtTop() throws {
     
     let systemUnderTest = RemoveSwiftOnoneSupport()
     
-    XCTAssertEqual(try systemUnderTest.process(input: "\nimport SwiftOnoneSupport\nimport Foundation"), "\nimport Foundation", "SwiftOnoneSupport should be removed, but it was not.")
+    XCTAssertEqual(try systemUnderTest.process(input: "import SwiftOnoneSupport\nimport Foundation"), "import Foundation", "SwiftOnoneSupport should be removed, but it was not.")
+    
+  }
+  
+  func testRemoveIfPresentInMiddle() throws {
+    
+    let systemUnderTest = RemoveSwiftOnoneSupport()
+    
+    XCTAssertEqual(try systemUnderTest.process(input: "import GuiseFramework\nimport SwiftOnoneSupport\nimport Foundation"), "import GuiseFramework\nimport Foundation", "SwiftOnoneSupport should be removed, but it was not.")
     
   }
   
@@ -15,7 +23,7 @@ class RemoveSwiftOnoneSupportTests: XCTestCase {
     
     let systemUnderTest = RemoveSwiftOnoneSupport()
     
-    XCTAssertEqual(try systemUnderTest.process(input: "\nimport GuiseFramework\nimport Foundation"), "\nimport GuiseFramework\nimport Foundation", "The input should not be modified, but it was.")
+    XCTAssertEqual(try systemUnderTest.process(input: "import GuiseFramework\nimport Foundation"), "import GuiseFramework\nimport Foundation", "The input should not be modified, but it was.")
     
   }
     

--- a/Tests/GuiseFrameworkTests/TextProcessors/RemoveSwiftOnoneSupportTests.swift
+++ b/Tests/GuiseFrameworkTests/TextProcessors/RemoveSwiftOnoneSupportTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import GuiseFramework
+
+class RemoveSwiftOnoneSupportTests: XCTestCase {
+  
+  func testRemoveIfPresent() throws {
+    
+    let systemUnderTest = RemoveSwiftOnoneSupport()
+    
+    XCTAssertEqual(try systemUnderTest.process(input: "\nimport SwiftOnoneSupport\nimport Foundation"), "\nimport Foundation", "SwiftOnoneSupport should be removed, but it was not.")
+    
+  }
+  
+  func testDoNotModifyIfNotPresent() throws {
+    
+    let systemUnderTest = RemoveSwiftOnoneSupport()
+    
+    XCTAssertEqual(try systemUnderTest.process(input: "\nimport GuiseFramework\nimport Foundation"), "\nimport GuiseFramework\nimport Foundation", "The input should not be modified, but it was.")
+    
+  }
+    
+}


### PR DESCRIPTION
Fix #5
Fix #6

Todo:
- Write tests for `GenerateCommand.swift`
- Ensure we are happy with regex replace for `RemoveComments.swift`. Currently this works fine, but deletes new lines between code, potentially consider new regex or figure out how to strip leading whitespace when using `sourcekitten`.