### PR TITLE
Sequence using Result instead of throws

### DIFF
--- a/Sources/GuiseFramework/APIGeneratorError.swift
+++ b/Sources/GuiseFramework/APIGeneratorError.swift
@@ -7,6 +7,16 @@ enum APIGeneratorError: Error, CustomStringConvertible {
   case failedToWrite(path: String, error: Error)
   case unexpectedError(error: Error)
   
+  init(error: Error) {
+    
+      if let error = error as? APIGeneratorError {
+        self = error
+      } else {
+        self = .unexpectedError(error: error)
+      }
+    
+  }
+  
   var description: String {
     
     switch self {


### PR DESCRIPTION
More an experiment than anything but if this is reasonable then it might be worth changing to Result throughout and dropping `throw` as it's not very composable

---

Why:
Having do/catch blocks all over the place can clutter things up and make
it harder to see the control flow of data. The Result type has
functions that allow for sequencing operations with a cleaner syntax
whilst still propagating errors.

This change addresses the need by:
Use Result rather that do/catch for sequencing the APIGeneration