### PR TITLE
Make TextProcessor Protocol more composable

### DIFF
--- a/Sources/GuiseFramework/CLI/GenerateCommand.swift
+++ b/Sources/GuiseFramework/CLI/GenerateCommand.swift
@@ -73,8 +73,11 @@ private extension GenerateCommand {
     }
     
     return { source in
-      Result(attempt: { try textProcessors.reduce(source, { try $1.process(input: $0) }) }).mapError({ .textProcessingFailed(error: $0) })
+      return textProcessors.reduce(.success(source)) { result, textProcessor in
+        return result.flatMap(textProcessor.process(input:))
+      }
     }
+    
   }
   
   func writeToFile(options: Options) -> (_ source: String) -> Result<Void, APIGeneratorError> {

--- a/Sources/GuiseFramework/TextProcessors/RemoveComments.swift
+++ b/Sources/GuiseFramework/TextProcessors/RemoveComments.swift
@@ -1,13 +1,15 @@
 import Foundation
+import Result
 
 struct RemoveComments: TextProcessor {
 
-  func process(input: String) throws -> String {
+  func process(input: String) -> Result<String, APIGeneratorError> {
 
-    return input
-      .split(separator: "\n", omittingEmptySubsequences: false)
-      .filter { $0.range(of: " *\\/{3}", options: .regularExpression) == nil }
-      .joined(separator: "\n")
+    return .success(
+      input.split(separator: "\n", omittingEmptySubsequences: false)
+           .filter { $0.range(of: " *\\/{3}", options: .regularExpression) == nil }
+           .joined(separator: "\n")
+    )
     
   }
   

--- a/Sources/GuiseFramework/TextProcessors/RemoveSwiftOnoneSupport.swift
+++ b/Sources/GuiseFramework/TextProcessors/RemoveSwiftOnoneSupport.swift
@@ -1,9 +1,12 @@
+import Result
+
 struct RemoveSwiftOnoneSupport: TextProcessor {
   
-  func process(input: String) throws -> String {
-    return input
-      .replacingOccurrences(of: "\nimport SwiftOnoneSupport", with: "")
-      .replacingOccurrences(of: "import SwiftOnoneSupport\n", with: "")
+  func process(input: String) -> Result<String, APIGeneratorError> {
+    return .success(
+      input.replacingOccurrences(of: "\nimport SwiftOnoneSupport", with: "")
+           .replacingOccurrences(of: "import SwiftOnoneSupport\n", with: "")
+    )
   }
   
 }

--- a/Sources/GuiseFramework/TextProcessors/TextProcessor.swift
+++ b/Sources/GuiseFramework/TextProcessors/TextProcessor.swift
@@ -1,3 +1,5 @@
+import Result
+
 protocol TextProcessor {
-  func process(input: String) throws -> String
+  func process(input: String) -> Result<String, APIGeneratorError>
 }

--- a/Tests/GuiseFrameworkTests/TextProcessors/RemoveCommentsTests.swift
+++ b/Tests/GuiseFrameworkTests/TextProcessors/RemoveCommentsTests.swift
@@ -1,9 +1,11 @@
 import XCTest
+import Result
+
 @testable import GuiseFramework
 
 class RemoveCommentsTests: XCTestCase {
   
-  func testStripComments() throws {
+  func testStripComments() {
     
     let input = """
 /// This is a doc comment for my structure
@@ -20,12 +22,12 @@ struct MyStructure {
 """
     
     let systemUnderTest = RemoveComments()
-    
-    XCTAssertEqual(try systemUnderTest.process(input: input), expected)
+
+    XCTAssertEqual(systemUnderTest.process(input: input).value, expected)
     
   }
   
-  func testStripCommentsDoNotRemoveWhitespaceLines() throws {
+  func testStripCommentsDoNotRemoveWhitespaceLines() {
     
     let input = """
 /// This is a doc comment for my structure
@@ -47,7 +49,7 @@ struct MyStructure {
     
     let systemUnderTest = RemoveComments()
     
-    XCTAssertEqual(try systemUnderTest.process(input: input), expected)
+    XCTAssertEqual(systemUnderTest.process(input: input).value, expected)
     
   }
   

--- a/Tests/GuiseFrameworkTests/TextProcessors/RemoveSwiftOnoneSupportTests.swift
+++ b/Tests/GuiseFrameworkTests/TextProcessors/RemoveSwiftOnoneSupportTests.swift
@@ -1,30 +1,38 @@
 import XCTest
+import Result
+
 @testable import GuiseFramework
 
 class RemoveSwiftOnoneSupportTests: XCTestCase {
   
-  func testRemoveIfPresentAtTop() throws {
+  func testRemoveIfPresentAtTop() {
     
     let systemUnderTest = RemoveSwiftOnoneSupport()
     
-    XCTAssertEqual(try systemUnderTest.process(input: "import SwiftOnoneSupport\nimport Foundation"), "import Foundation", "SwiftOnoneSupport should be removed, but it was not.")
+    let result = systemUnderTest.process(input: "import SwiftOnoneSupport\nimport Foundation")
+    
+    XCTAssertEqual(result.value, "import Foundation", "SwiftOnoneSupport should be removed, but it was not.")
     
   }
   
-  func testRemoveIfPresentInMiddle() throws {
+  func testRemoveIfPresentInMiddle() {
     
     let systemUnderTest = RemoveSwiftOnoneSupport()
     
-    XCTAssertEqual(try systemUnderTest.process(input: "import GuiseFramework\nimport SwiftOnoneSupport\nimport Foundation"), "import GuiseFramework\nimport Foundation", "SwiftOnoneSupport should be removed, but it was not.")
-    
+    let result = systemUnderTest.process(input: "import GuiseFramework\nimport SwiftOnoneSupport\nimport Foundation")
+
+    XCTAssertEqual(result.value, "import GuiseFramework\nimport Foundation", "SwiftOnoneSupport should be removed, but it was not.")
+
   }
   
-  func testDoNotModifyIfNotPresent() throws {
+  func testDoNotModifyIfNotPresent() {
     
     let systemUnderTest = RemoveSwiftOnoneSupport()
     
-    XCTAssertEqual(try systemUnderTest.process(input: "import GuiseFramework\nimport Foundation"), "import GuiseFramework\nimport Foundation", "The input should not be modified, but it was.")
-    
+    let result = systemUnderTest.process(input: "import GuiseFramework\nimport Foundation")
+
+    XCTAssertEqual(result.value, "import GuiseFramework\nimport Foundation", "The input should not be modified, but it was.")
+
   }
     
 }


### PR DESCRIPTION
Why:
Having do/catch blocks means we have to re-map
the errors making the call-site look a litte odd.
The result type offers a cleaner way to represent
the value and the error, which in this case is
already wrapped up in the type we need.

This change:
Use Result over do/catch for TextProcessor