### PR TITLE
Simplify `Version` type

### DIFF
--- a/Sources/GuiseFramework/CLI/VersionCommand.swift
+++ b/Sources/GuiseFramework/CLI/VersionCommand.swift
@@ -13,7 +13,7 @@ struct VersionCommand: CommandProtocol {
   
   /// Runs this subcommand with the given options.
   public func run(_ options: NoOptions<APIGeneratorError>) -> Result<(), APIGeneratorError> {
-    print(Version.current.value)
+    print(Version)
     return .success(())
   }
   

--- a/Sources/GuiseFramework/Version.swift
+++ b/Sources/GuiseFramework/Version.swift
@@ -1,4 +1,1 @@
-public struct Version {
-  public let value: String
-  public static let current = Version(value: "1.0.1")
-}
+let Version = "1.0.1"


### PR DESCRIPTION
Why:
The `Version` type is only used to hold a string constant. The current
implementation seems to be a little over the top creating a singleton of
a type that holds a single string. This can be reduced to a single
constant.

This also has the benefit that if you automate tagging at some point in the future this is a much easier file to manipulate