### PR TITLE
Update APIGenerator to read `ARCHS` instead of `CURRENT_ARCH`

### DIFF
--- a/Sources/GuiseFramework/APIGenerator.swift
+++ b/Sources/GuiseFramework/APIGenerator.swift
@@ -11,12 +11,16 @@ struct APIGenerator {
       throw APIGeneratorError.failedToExtractToolchainIdentifier(plistPath: "\(buildArguments.toolchainDir)/ToolchainInfo.plist)")
     }
     
+    guard let currentArch = buildArguments.archs.split(separator: " ").first else {
+        throw APIGeneratorError.invalidArgument(description: "ARCHS expected to have space-separated list of identifiers.")
+    }
+    
     let yaml = """
     key.request: source.request.editor.open.interface
     key.name: "\(NSUUID().uuidString)"
     key.compilerargs:
     - "-target"
-    - "\(buildArguments.currentArch)-apple-\(buildArguments.swiftPlatformTargetPrefix)\(buildArguments.deploymentTarget)"
+    - "\(currentArch)-apple-\(buildArguments.swiftPlatformTargetPrefix)\(buildArguments.deploymentTarget)"
     - "-sdk"
     - "\(buildArguments.sdkDir)"
     - "-I"

--- a/Sources/GuiseFramework/BuildArguments.swift
+++ b/Sources/GuiseFramework/BuildArguments.swift
@@ -3,7 +3,7 @@ import Foundation
 struct BuildArguments: Decodable {
   
   let configurationBuildDir: String
-  let currentArch: String
+  let archs: String
   let phoneOSDeploymentTarget: String?
   let macOSDeploymentTarget: String?
   let productModuleName: String
@@ -18,7 +18,7 @@ struct BuildArguments: Decodable {
   
   enum CodingKeys: String, CodingKey {
     case configurationBuildDir = "CONFIGURATION_BUILD_DIR"
-    case currentArch = "CURRENT_ARCH"
+    case archs = "ARCHS"
     case phoneOSDeploymentTarget = "IPHONEOS_DEPLOYMENT_TARGET"
     case macOSDeploymentTarget = "MACOSX_DEPLOYMENT_TARGET"
     case productModuleName = "PRODUCT_MODULE_NAME"

--- a/Tests/GuiseFrameworkTests/BuildArgumentTests.swift
+++ b/Tests/GuiseFrameworkTests/BuildArgumentTests.swift
@@ -5,7 +5,7 @@ final class BuildArgumentTests: XCTestCase {
 
   let environment = [
     "CONFIGURATION_BUILD_DIR": "1",
-    "CURRENT_ARCH": "2",
+    "ARCHS": "2 A B",
     "PRODUCT_MODULE_NAME": "3",
     "PROJECT_DIR": "4",
     "SDK_DIR": "5",
@@ -22,7 +22,7 @@ final class BuildArgumentTests: XCTestCase {
     let buildArguments = try extractor.makeBuildArguments()
     
     XCTAssertEqual(buildArguments.configurationBuildDir, "1")
-    XCTAssertEqual(buildArguments.currentArch, "2")
+    XCTAssertEqual(buildArguments.archs, "2 A B")
     XCTAssertEqual(buildArguments.productModuleName, "3")
     XCTAssertEqual(buildArguments.projectDir, "4")
     XCTAssertEqual(buildArguments.sdkDir, "5")


### PR DESCRIPTION
Why:
Xcode 10 dropped support for `CURRENT_ARCH`.
See: https://github.com/ollieatkinson/Guise/issues/26

This change addresses the need by:
Change `CURRENT_ARCH` to `ARCHS`

Fix https://github.com/ollieatkinson/Guise/issues/26